### PR TITLE
Fix GetProxies()

### DIFF
--- a/main.py
+++ b/main.py
@@ -85,7 +85,7 @@ class PlaceClient:
     def GetProxies(self, proxies):
         proxieslist = []
         for i in proxies:
-            proxieslist[len(proxieslist)] = {"https": i}
+            proxieslist.append({"https": i})
         return proxieslist
 
     def GetRandomProxy(self):


### PR DESCRIPTION
The syntax: "list[len(list)] = x" doesn't work in Python. Instead, .append() should be used to add an element to a list.