### PR TITLE
removing bs4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ Pillow~=9.1.0
 websocket-client~=1.3.2
 click==8.1.2
 loguru==0.6.0
-bs4~=0.0.1
 beautifulsoup4~=4.10.0


### PR DESCRIPTION
removed bs4: https://pypi.org/project/bs4/ this is not BeautifulSoup4 package.