### PR TITLE
sort canvas images before stitching

### DIFF
--- a/main.py
+++ b/main.py
@@ -318,16 +318,18 @@ class PlaceClient:
                     logger.debug("Image ID: {}", img_id)
                     if img_id in canvas_sockets:
                         logger.debug("Getting image: {}", msg["data"]["name"])
-                        imgs.append([
-                            img_id,
-                            Image.open(
-                                BytesIO(
-                                    requests.get(
-                                        msg["data"]["name"], stream=True
-                                    ).content
-                                )
-                            )
-                        ])
+                        imgs.append(
+                            [
+                                img_id,
+                                Image.open(
+                                    BytesIO(
+                                        requests.get(
+                                            msg["data"]["name"], stream=True
+                                        ).content
+                                    )
+                                ),
+                            ]
+                        )
                         canvas_sockets.remove(img_id)
                         logger.debug(
                             "Canvas sockets remaining: {}", len(canvas_sockets)

--- a/main.py
+++ b/main.py
@@ -318,7 +318,8 @@ class PlaceClient:
                     logger.debug("Image ID: {}", img_id)
                     if img_id in canvas_sockets:
                         logger.debug("Getting image: {}", msg["data"]["name"])
-                        imgs.append(
+                        imgs.append([
+                            img_id,
                             Image.open(
                                 BytesIO(
                                     requests.get(
@@ -326,7 +327,7 @@ class PlaceClient:
                                     ).content
                                 )
                             )
-                        )
+                        ])
                         canvas_sockets.remove(img_id)
                         logger.debug(
                             "Canvas sockets remaining: {}", len(canvas_sockets)
@@ -345,10 +346,10 @@ class PlaceClient:
 
         new_img = Image.new("RGB", (new_img_width, new_img_height))
         dx_offset = 0
-        for idx, img in enumerate(imgs):
-            logger.debug("Adding image: {}", img)
+        for idx, img in enumerate(sorted(imgs, key=lambda x: x[0])):
+            logger.debug("Adding image (ID {}): {}", img[0], img[1])
             dx_offset = int(canvas_details["canvasConfigurations"][idx]["dx"])
-            new_img.paste(img, (dx_offset, 0))
+            new_img.paste(img[1], (dx_offset, 0))
 
         return new_img
 


### PR DESCRIPTION
Fixes #217 

The two halves of the canvas were sometimes being stitched together in swapped positions, so pixel color detection would be completely wrong. Pretty sure this is because the websocket events could arrive at different times. Now we're ordering the list of images based on the websocket ID before stitching the two halves.