### PR TITLE
Fixed tuple index out of range bug

### DIFF
--- a/main.py
+++ b/main.py
@@ -103,7 +103,7 @@ class PlaceClient:
 
     def closest_color(self, target_rgb):
         r, g, b = target_rgb[:3]
-        print(f"target_rgb length: {len(target_rgb)}")
+        #print(f"target_rgb length: {len(target_rgb)}")
         if target_rgb[2] != 0:
             color_diffs = []
             for color in self.rgb_colors_array:

--- a/main.py
+++ b/main.py
@@ -103,7 +103,8 @@ class PlaceClient:
 
     def closest_color(self, target_rgb):
         r, g, b = target_rgb[:3]
-        if target_rgb[3] != 0:
+        print(f"target_rgb length: {len(target_rgb)}")
+        if target_rgb[2] != 0:
             color_diffs = []
             for color in self.rgb_colors_array:
                 cr, cg, cb = color


### PR DESCRIPTION
Previously it would give an error:
```
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/usr/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "main.py", line 587, in task
    current_r, current_c, new_rgb = self.get_unset_pixel(
  File "main.py", line 406, in get_unset_pixel
    new_rgb = self.closest_color(target_rgb)
  File "main.py", line 107, in closest_color
    if target_rgb[3] != 0:
IndexError: tuple index out of range
```
which was caused by the index it was looking at to be wrong, the length of `target_rgb` is 3, but it was looking at index 3 (when the last index is 2, since it counts from 0)
