### PR TITLE
Fixes support for transparent/skipover pixels

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Note: Please use https://jsonlint.com/ to check that your JSON file is correctly
 ### Notes
 
 - Change image.jpg/png to specify what image to draw. One pixel is drawn every 5 minutes. PNG takes priority over JPG.
+- Pixels with color (69, 42, 0) in the image will be skipped over, useful for non-rectangular drawings.
 
 ## Run the Script
 

--- a/main.py
+++ b/main.py
@@ -397,11 +397,11 @@ class PlaceClient:
                     "{}, {}, {}, {}",
                     pix2[x + self.pixel_x_start, y + self.pixel_y_start],
                     new_rgb,
-                    target_rgb != (69, 42, 0, 0),
+                    target_rgb[:3] != (69, 42, 0),
                     pix2[x, y] != new_rgb,
                 )
 
-                if target_rgb != (69, 42, 0, 0):
+                if target_rgb[:3] != (69, 42, 0):
                     logger.debug(
                         "Thread #{} : Replacing {} pixel at: {},{} with {} color",
                         index,

--- a/main.py
+++ b/main.py
@@ -397,11 +397,11 @@ class PlaceClient:
                     "{}, {}, {}, {}",
                     pix2[x + self.pixel_x_start, y + self.pixel_y_start],
                     new_rgb,
-                    new_rgb != (69, 42, 0),
+                    target_rgb != (69, 42, 0),
                     pix2[x, y] != new_rgb,
                 )
 
-                if new_rgb != (69, 42, 0):
+                if target_rgb != (69, 42, 0):
                     logger.debug(
                         "Thread #{} : Replacing {} pixel at: {},{} with {} color",
                         index,
@@ -412,7 +412,7 @@ class PlaceClient:
                     )
                     break
                 else:
-                    logger.info("TransparrentPixel")
+                    logger.info("Transparent Pixel at {}, {} skipped", x + self.pixel_x_start, y + self.pixel_y_start)
             x += 1
             loopedOnce = True
         return x, y, new_rgb

--- a/main.py
+++ b/main.py
@@ -412,7 +412,11 @@ class PlaceClient:
                     )
                     break
                 else:
-                    logger.info("Transparent Pixel at {}, {} skipped", x + self.pixel_x_start, y + self.pixel_y_start)
+                    logger.info(
+                        "Transparent Pixel at {}, {} skipped",
+                        x + self.pixel_x_start,
+                        y + self.pixel_y_start,
+                    )
             x += 1
             loopedOnce = True
         return x, y, new_rgb

--- a/main.py
+++ b/main.py
@@ -397,11 +397,11 @@ class PlaceClient:
                     "{}, {}, {}, {}",
                     pix2[x + self.pixel_x_start, y + self.pixel_y_start],
                     new_rgb,
-                    target_rgb != (69, 42, 0),
+                    target_rgb != (69, 42, 0, 0),
                     pix2[x, y] != new_rgb,
                 )
 
-                if target_rgb != (69, 42, 0):
+                if target_rgb != (69, 42, 0, 0):
                     logger.debug(
                         "Thread #{} : Replacing {} pixel at: {},{} with {} color",
                         index,


### PR DESCRIPTION
Makes pixels with color (69, 42, 0) actually skipped again and adds it to README, just a mild annoyance really since this can easily be changed locally, but still something good to keep working.