### PR TITLE
debug logging for error on response

### DIFF
--- a/main.py
+++ b/main.py
@@ -270,6 +270,7 @@ class PlaceClient:
         # If we don't get data, it means we've been rate limited.
         # If we do, a pixel has been successfully placed.
         if response.json()["data"] is None:
+            logger.debug(response.json().get("errors"))
             waitTime = math.floor(
                 response.json()["errors"][0]["extensions"]["nextAvailablePixelTs"]
             )


### PR DESCRIPTION
litterally to allow `debug` to print the response's error key at line 272