### PR TITLE
Transparency and config changes

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -1,7 +1,7 @@
 {
     "image_path": "image.jpg",
     "image_start_coords": [741, 610],
-    "legacy_transparency": false,
+    "legacy_transparency": true,
     "thread_delay": 2,
     "unverified_place_frequency": false,
     "compact_logging": true,

--- a/config_example.json
+++ b/config_example.json
@@ -1,6 +1,7 @@
 {
     "image_path": "image.jpg",
     "image_start_coords": [741, 610],
+    "legacy_transparency": false,
     "thread_delay": 2,
     "unverified_place_frequency": false,
     "compact_logging": true,

--- a/main.py
+++ b/main.py
@@ -46,6 +46,12 @@ class PlaceClient:
             and self.json_data["unverified_place_frequency"] is not None
             else False
         )
+        self.legacy_transparency = (
+            self.json_data["legacy_transparency"]
+            if "legacy_transparency" in self.json_data
+            and self.json_data["legacy_transparency"] is not None
+            else False
+        )
         self.proxies = (
             self.GetProxies(self.json_data["proxies"])
             if "proxies" in self.json_data and self.json_data["proxies"] is not None
@@ -510,11 +516,12 @@ class PlaceClient:
                     "{}, {}, {}, {}",
                     pix2[x + self.pixel_x_start, y + self.pixel_y_start],
                     new_rgb,
-                    target_rgb[:3] != (69, 42, 0) and new_rgb != (69, 42, 0),
+                    new_rgb != (69, 42, 0),
                     pix2[x, y] != new_rgb,
                 )
 
-                if target_rgb[:3] != (69, 42, 0) and new_rgb != (69, 42, 0):
+                #(69, 42, 0) is a special color reserved for transparency.
+                if new_rgb != (69, 42, 0):
                     logger.debug(
                         "Thread #{} : Replacing {} pixel at: {},{} with {} color",
                         index,

--- a/main.py
+++ b/main.py
@@ -510,7 +510,7 @@ class PlaceClient:
 
             target_rgb = self.pix[x, y]
 
-            new_rgb = ColorMapper.closest_color(target_rgb, self.rgb_colors_array)
+            new_rgb = ColorMapper.closest_color(target_rgb, self.rgb_colors_array, self.legacy_transparency)
             if pix2[x + self.pixel_x_start, y + self.pixel_y_start] != new_rgb:
                 logger.debug(
                     "{}, {}, {}, {}",

--- a/main.py
+++ b/main.py
@@ -520,7 +520,7 @@ class PlaceClient:
                     pix2[x, y] != new_rgb,
                 )
 
-                #(69, 42, 0) is a special color reserved for transparency.
+                # (69, 42, 0) is a special color reserved for transparency.
                 if new_rgb != (69, 42, 0):
                     logger.debug(
                         "Thread #{} : Replacing {} pixel at: {},{} with {} color",

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ class PlaceClient:
             self.json_data["legacy_transparency"]
             if "legacy_transparency" in self.json_data
             and self.json_data["legacy_transparency"] is not None
-            else False
+            else True
         )
         proxy.Init(self)
 

--- a/main.py
+++ b/main.py
@@ -355,7 +355,9 @@ class PlaceClient:
 
             target_rgb = self.pix[x, y]
 
-            new_rgb = ColorMapper.closest_color(target_rgb, self.rgb_colors_array, self.legacy_transparency)
+            new_rgb = ColorMapper.closest_color(
+                target_rgb, self.rgb_colors_array, self.legacy_transparency
+            )
             if pix2[x + self.pixel_x_start, y + self.pixel_y_start] != new_rgb:
                 logger.debug(
                     "{}, {}, {}, {}",

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -89,7 +89,7 @@ class ColorMapper:
     @staticmethod
     def closest_color(target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool):
         """Find the closest rgb color from palette to a target rgb color, as well as handling transparency"""
- 
+        
         # first check is for the alpha channel transparency in ex. png
         if target_rgb[3] == 0:
             return (69, 42, 0)

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -89,7 +89,7 @@ class ColorMapper:
     @staticmethod
     def closest_color(target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool):
         """Find the closest rgb color from palette to a target rgb color, as well as handling transparency"""
-        
+
         # first check is for the alpha channel transparency in ex. png
         if target_rgb[3] == 0:
             return (69, 42, 0)

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -86,18 +86,23 @@ class ColorMapper:
         return "Invalid Color ({})".format(str(color_id))
 
     @staticmethod
-    def closest_color(target_rgb: tuple, rgb_colors_array: list):
-        """Find the closest rgb color from palette to a target rgb color"""
-        r, g, b = target_rgb[:3]
-        if target_rgb[3] != 0:
-            color_diffs = []
-            for color in rgb_colors_array:
-                cr, cg, cb = color
-                color_diff = math.sqrt((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2)
-                color_diffs.append((color_diff, color))
-            return min(color_diffs)[1]
-        else:
+    def closest_color(target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool):
+        """Find the closest rgb color from palette to a target rgb color, as well as handling transparency"""
+        
+        #first check is for the alpha channel transparency in ex. png
+        if target_rgb[3] == 0:
             return (69, 42, 0)
+        #second check is for the legacy method of transparency using hex #452A00.
+        if target_rgb[:3] == (69, 42, 0) and legacy_transparency:
+            return (69, 42, 0)
+
+        r, g, b = target_rgb[:3]
+        color_diffs = []
+        for color in rgb_colors_array:
+            cr, cg, cb = color
+            color_diff = math.sqrt((r - cr) ** 2 + (g - cg) ** 2 + (b - cb) ** 2)
+            color_diffs.append((color_diff, color))
+        return min(color_diffs)[1]
 
     @staticmethod
     def generate_rgb_colors_array():

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -87,7 +87,9 @@ class ColorMapper:
         return "Invalid Color ({})".format(str(color_id))
 
     @staticmethod
-    def closest_color(target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool):
+    def closest_color(
+        target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool
+    ):
         """Find the closest rgb color from palette to a target rgb color, as well as handling transparency"""
 
         # first check is for the alpha channel transparency in ex. png

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -89,11 +89,11 @@ class ColorMapper:
     @staticmethod
     def closest_color(target_rgb: tuple, rgb_colors_array: list, legacy_transparency: bool):
         """Find the closest rgb color from palette to a target rgb color, as well as handling transparency"""
-        
-        #first check is for the alpha channel transparency in ex. png
+ 
+        # first check is for the alpha channel transparency in ex. png
         if target_rgb[3] == 0:
             return (69, 42, 0)
-        #second check is for the legacy method of transparency using hex #452A00.
+        # second check is for the legacy method of transparency using hex #452A00.
         if target_rgb[:3] == (69, 42, 0) and legacy_transparency:
             return (69, 42, 0)
 

--- a/src/mappings.py
+++ b/src/mappings.py
@@ -40,6 +40,7 @@ class ColorMapper:
 
     # map of pixel color ids to verbose name (for debugging)
     NAME_MAP = {
+        0: "Darkest Red",
         1: "Dark Red",
         2: "Bright Red",
         3: "Orange",


### PR DESCRIPTION
add config option legacy_transparency to enable the old RGB (69, 42, 0) as transparent alongside the new alpha transparency, and move most transparency handling to mappings.py