### PR TITLE
Fix some grammar and improve mac tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ This is a script to draw an image onto r/place (<https://www.reddit.com/r/place/
 
 -   [Latest Version of Python 3](https://www.python.org/downloads/)
 
-## MacOSX
+## macOS
 
-If you want to use tor on MacOSX. you'll need to provide your own tor binary and start it manually. deactivate the "use_builtin tor"
-option in the config and make sure you configure your tor to use the specified ports and password. 
+If you want to use tor on macOS. you'll need to provide your own tor binary or install it via [Homebrew](https://brew.sh) using ``brew install tor``, and start it manually.
+
+Make sure to deactivate the "use_builtin tor"
+option in the config and configure your tor to use the correct ports and password. 
 
 *Please note that socks proxy connection to tor doesn't work for the time being, so the config value is for an httpTunnel port*
 
 ## Get Started
 
-Move the file 'config_example.json' to config.json
+Move the file 'config_example.json' to 'config.json'
 
 Edit the values to replace with actual credentials and values
 
@@ -81,7 +83,7 @@ Note: Please use https://jsonlint.com/ to check that your JSON file is correctly
 start.bat or startverbose.bat
 ```
 
-### Unix-like (Linux, MacOS etc.)
+### Unix-like (Linux, macOS etc.)
 
 ```shell
 chmod +x start.sh startverbose.sh
@@ -163,7 +165,7 @@ Note that when using the included binaries, only the tunnel port is explicitly s
 
 <h3>If you want to use your own binaries, follow these steps:</h3>
 
-- Get tor standalone for your platform [here](https://www.torproject.org/download/tor/). For Windows just use the expert bundle. For MacOS you'll have to compile the binaries yourself or get them from somewhere else, which is both out of the scope of this guide.
+- Get tor standalone for your platform [here](https://www.torproject.org/download/tor/). For Windows just use the expert bundle. For macOS, you can use [Homebrew](https://brew.sh) to install tor: ``brew install tor``.
 - In your tor folder, create a file named ``torrc``. Copy [this](https://github.com/torproject/tor/blob/main/src/config/torrc.sample.in) into it.
 - Search for ``ControlPort`` in your torrc file and uncomment it. Change the port number to your desired control port.
 - Decide on the password you want to use. Run ``tor --hash-password PASSWORD`` from a terminal in the folder with your tor executable, with "PASSWORD" being your desired password. Copy the resulting hash.


### PR DESCRIPTION
- Changed instances of MacOS or MacOSX to ‘macOS’ as it is the correct capitalization

- Added Homebrew installation method for macOS (widely used mac package manager)

- A couple general readability improvements