### PR TITLE
Allow users to specify tor proxy ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Tor can be used as an alternative to normal proxies. Note that currently, you ca
 
 ```json
 "using_tor": false,
+"tor_ip": "127.0.0.1",
 "tor_port": 1881,
 "tor_control_port": 9051,
 "tor_password": "Passwort",
@@ -155,6 +156,7 @@ Tor can be used as an alternative to normal proxies. Note that currently, you ca
 
 The config values are as follows:
 - Deactivates or activates tor.
+- Sets the ip/hostname of the tor proxy to use
 - Sets the httptunnel port that should be used.
 - Sets the tor control port.
 - Sets the password (leave it as "Passwort" if you want to use the default binaries.

--- a/config_example.json
+++ b/config_example.json
@@ -6,6 +6,7 @@
     "unverified_place_frequency": false,
     "compact_logging": true,
     "using_tor": false,
+    "tor_ip": "127.0.0.1",
     "tor_port": 1881,
     "tor_control_port": 9051,
     "tor_password": "Passwort",

--- a/src/proxy.py
+++ b/src/proxy.py
@@ -55,10 +55,18 @@ def Init(self):
         and self.json_data["tor_control_port"] is not None
         else 9051
     )
+    self.tor_ip = (
+        self.json_data["tor_ip"]
+        if "tor_ip" in self.json_data
+        and self.json_data["tor_ip"] is not None
+        else "127.0.0.1"
+    )
+
+    print(self.tor_ip)
 
     # tor connection
     if self.using_tor:
-        self.proxies = get_proxies(self, ["127.0.0.1:" + str(self.tor_port)])
+        self.proxies = get_proxies(self, [self.tor_ip + ":" + str(self.tor_port)])
         if self.use_builtin_tor:
             subprocess.Popen(
                 '"'


### PR DESCRIPTION
Allow users to specify tor proxy ip via a config option.