### PR TITLE
Fixing small typo in color mapping

### DIFF
--- a/src/mappings.py
+++ b/src/mappings.py
@@ -15,7 +15,7 @@ class ColorMapper:
         "#7EED56": 8,  # light green
         "#00756F": 9,  # dark teal
         "#009EAA": 10,  # teal
-        "#00CC00": 11,  # light teal
+        "#00CCC0": 11,  # light teal
         "#2450A4": 12,  # dark blue
         "#3690EA": 13,  # blue
         "#51E9F4": 14,  # light blue


### PR DESCRIPTION
light teal was previously assumed to be #00CC00, which is a bright
green, instead of the actuall #00CCC0