### PR TITLE
Add required dependencies in order to build Pillow in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,11 @@ FROM python:3.10.4-alpine
 WORKDIR /usr/src/app
 
 COPY requirements.txt ./
+RUN apk add python3-dev py3-setuptools gcc linux-headers libc-dev
+RUN apk add tiff-dev jpeg-dev openjpeg-dev zlib-dev freetype-dev lcms2-dev \
+    libwebp-dev tcl-dev tk-dev harfbuzz-dev fribidi-dev libimagequant-dev \
+    libxcb-dev libpng-dev
+
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
Was unable to build the Dockerfile. Ran in to issues building Pillow specified in requirements.txt. Seems like it required some additional dependencies for Alpine. All the image related dependencies were copied from Pillow's official documentation (https://pillow.readthedocs.io/en/stable/installation.html#building-on-linux).

Then there were some general build-tools missing as well.

